### PR TITLE
update link to email list

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ base around this topic.
 [View meeting minutes](./meeting-minutes.md)
 
 ## Mailing list
-We use the CHAOSS mailing list: https://wiki.linuxfoundation.org/chaoss/metrics#mail-list
+We use the [CHAOSS mailing list](https://chaoss.community/participate/#user-content-join-the-mailing-list).
 Please append email subject with: [wg-di]
 
 ## Metrics Work

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To be done
 This project is open to anyone interested in the topic of diversity and inclusion. And this includes several areas of work such as **diversity and inclusion** from a broader perspective, mining software repositories, **Python** development,
 **tech writing**, people interested in **speaking** at events and others.
 
-The collaboration guide is still in progress, but a first good step would be to introduce yourself at the [CHAOSS Metrics](https://lists.linuxfoundation.org/mailman/listinfo/oss-health-metrics) or [CHAOSS Software](https://lists.linuxfoundation.org/mailman/listinfo/chaoss-software) mailing lists explaining a bit your interest.
+The collaboration guide is still in progress, but a first good step would be to introduce yourself at the [CHAOSS mailing list](https://chaoss.community/participate/#user-content-join-the-mailing-list) explaining a bit your interest.
 
 Most of the work in the metrics side will be done through pull requests to the markdown files containing discussions
 about the metrics used or to be used. This is the same method as when updating the software side of the project.


### PR DESCRIPTION
Background: the mailing lists are changing soon and we only use one, not two, mailing lists for CHAOSS.