### PR TITLE
Fixed focus area page links

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ base around this topic.
 
 We are compiling [dimensions of diversity and inclusion](./di_metrics.md) that can be used in the following areas of analysis:
 
-1. [Event Diversity](./goal_events.md)
+1. [Event Diversity](./focus_areas/events/goal_events.md)
 2. [Contributor Community Diversity](./goal_contribution.md)
 3. [Communication Inclusivity](./goal_communication.md)
 4. [Recognition of Good Work](./goal_recognition.md)

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ base around this topic.
 We are compiling [dimensions of diversity and inclusion](./di_metrics.md) that can be used in the following areas of analysis:
 
 1. [Event Diversity](./focus_areas/events/goal_events.md)
-2. [Contributor Community Diversity](./goal_contribution.md)
-3. [Communication Inclusivity](./goal_communication.md)
-4. [Recognition of Good Work](./goal_recognition.md)
-5. [Leadership](./goal_leadership.md)
-6. [Governance](./goal_governance.md)
-7. [Project Places](./goal_project_places.md)
+2. [Contributor Community Diversity](./focus_areas/contribution/goal_contribution.md)
+3. [Communication Inclusivity](./focus_areas/communication/goal_communication.md)
+4. [Recognition of Good Work](./focus_areas/recognition/goal_recognition.md)
+5. [Leadership](./focus_areas/leadership/goal_leadership.md)
+6. [Governance](./focus_areas/governance/goal_governance.md)
+7. [Project Places](./focus_areas/project_and_community/goal_project_and_communities.md)
 
 Each area lists a collection of relevant questions. If you are interested in answering a question for your community, go to the associated resource page where we collect strategies for answering the question.
 


### PR DESCRIPTION
To make it easier to find things, I've fixed a few of the links in the readme that we mangled when we restructured the focus area section of the repo.