### PR TITLE
first version of the speaker demographics event focus area 

### DIFF
--- a/focus_areas/events/speaker_demographics.md
+++ b/focus_areas/events/speaker_demographics.md
@@ -6,7 +6,7 @@
 
 Please feel free to [contribute](https://github.com/chaoss/wg-diversity-inclusion/blob/master/CONTRIBUTING.md) and improve this document.
 
-## 0. Question
+## Question
 
 **Question:** How well does the speaker lineup for the event represent a diverse set of demographics?
 

--- a/focus_areas/events/speaker_demographics.md
+++ b/focus_areas/events/speaker_demographics.md
@@ -4,7 +4,7 @@
 
 **This is a work in process document being used to gather feedback and may not yet represent the views of the CHAOSS project.**
 
-Please feel free to contribute and improve this document.
+Please feel free to [contribute](https://github.com/chaoss/wg-diversity-inclusion/blob/master/CONTRIBUTING.md) and improve this document.
 
 ## 0. Question
 

--- a/focus_areas/events/speaker_demographics.md
+++ b/focus_areas/events/speaker_demographics.md
@@ -1,10 +1,12 @@
+# Event Diversity - Speaker Demographics
+
 ## Disclaimer / Caveats
 
 **This is a work in process document being used to gather feedback and may not yet represent the views of the CHAOSS project.**
 
 Please feel free to contribute and improve this document.
 
-# Event Diversity - Speaker Demographics
+## 0. Question
 
 **Question:** How well does the speaker lineup for the event represent a diverse set of demographics?
 

--- a/focus_areas/events/speaker_demographics.md
+++ b/focus_areas/events/speaker_demographics.md
@@ -1,0 +1,44 @@
+## Disclaimer / Caveats
+
+**This is a work in process document being used to gather feedback and may not yet represent the views of the CHAOSS project.**
+
+Please feel free to contribute and improve this document.
+
+# Event Diversity - Speaker Demographics
+
+**Question:** How well does the speaker lineup for the event represent a diverse set of demographics?
+
+## 1. Description
+
+Speakers with diverse backgrounds who represent a variety of demographics help an event provide different viewpoints and a broader perspective. Events with diverse speakers allow people from a variety of different backgrounds feel more included in an event when they see people with similar characteristics in a position of authority (speaking).
+
+## 2. Sample Objectives
+- Speakers are from diverse backgrounds.
+- Speakers are diverse when grouped by keynotes, sessions, and tracks.
+- Repeat speakers are from diverse backgrounds (retention). 
+
+## 3. Sample Strategies
+- Review conference website to gather data.
+- Survey and / or interview speakers and attendees.
+- Diverse proposals submitted compared to those who were accepted
+- Registration data or event organizers may be able to provide data/stats
+
+## 4. Sample Success Metrics
+
+_Qualitative_
+
+- Interview speakers and attendees to understand more about why the speakers did or did not meet their diversity and inclusion expectations.
+  * Interview question (ask speakers): What can we do to improve the diversity and inclusion of speakers at this event?
+  * Interview question (ask all attendees): Did you feel represented by the speakers?
+
+_Quantitative_
+
+- Survey speakers and attendees to learn to what extent the event met their diversity and inclusion expectations.
+  * Interview question (ask all attendees): How well did the event meet your diversity and inclusion expectations? (likert scale (e.g., 1-5) answer)
+- Use the event website, registration data, and other available details about speakers to quantify speaker diversity.
+  * Other details may include speakers’ twitter account, listed pronouns, descriptions, or other speaking engagements.
+
+## 5. Resources
+- TBD
+
+

--- a/focus_areas/events/speaker_demographics.md
+++ b/focus_areas/events/speaker_demographics.md
@@ -10,7 +10,7 @@ Please feel free to contribute and improve this document.
 
 ## 1. Description
 
-Speakers with diverse backgrounds who represent a variety of demographics help an event provide different viewpoints and a broader perspective. Events with diverse speakers allow people from a variety of different backgrounds feel more included in an event when they see people with similar characteristics in a position of authority (speaking).
+Speakers with diverse backgrounds who represent a [variety of demographics](https://github.com/chaoss/wg-diversity-inclusion/blob/master/di_metrics.md) help an event provide different viewpoints and a broader perspective. Events with diverse speakers allow people from a variety of different backgrounds feel more included in an event when they see people with similar characteristics in a position of authority (speaking).
 
 ## 2. Sample Objectives
 - Speakers are from diverse backgrounds.


### PR DESCRIPTION
Moving this from Google Docs to GitHub for wider input.

@emmairwin - how does this look for a standard disclaimer that we can use for all of the focus area pages while we work on them? Does it make sense to put it above the title the way I have it? It seemed less disruptive there, I think.