### PR TITLE
Display Focus Areas as a table

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ We are compiling [dimensions of diversity and inclusion](./di_metrics.md) that c
 |4. [Recognition of Good Work](./focus_areas/recognition/) | Identify how we recognize/reward good work in our community.|
 |5. [Leadership](./focus_areas/leadership/) | Identify how healthy our community leadership is.|
 |6. [Governance](./focus_areas/governance/) | Identify how diverse and inclusive our governance is.|
-|7. [Project Places](./focus_areas/project_and_community/) | Identify how diverse and inclusive our project places, where community engagement occurs, are.|
+|7. [Project and Community](./focus_areas/project_and_community/) | Identify how diverse and inclusive our project places, where community engagement occurs, are.|
 
 Each area lists a collection of relevant questions. If you are interested in answering a question for your community, go to the associated resource page where we collect strategies for answering the question.
 

--- a/README.md
+++ b/README.md
@@ -60,17 +60,19 @@ base around this topic.
   * Others
 
 
-## Structure of Repository
+## Metrics Focus Areas
 
 We are compiling [dimensions of diversity and inclusion](./di_metrics.md) that can be used in the following areas of analysis:
 
-1. [Event Diversity](./focus_areas/events/)
-2. [Contributor Community Diversity](./focus_areas/contribution/)
-3. [Communication Inclusivity](./focus_areas/communication/)
-4. [Recognition of Good Work](./focus_areas/recognition/)
-5. [Leadership](./focus_areas/leadership/)
-6. [Governance](./focus_areas/governance/)
-7. [Project Places](./focus_areas/project_and_community/)
+| Focus Area | Goal |
+| --- | --- |
+|1. [Event Diversity](./focus_areas/events/) | Identify the diversity and inclusion at events. |
+|2. [Contributor Community Diversity](./focus_areas/contribution/) | Identify the diversity of the contributions within a community, and howe those different contributions are valued.|
+|3. [Communication Inclusivity](./focus_areas/communication/) | Identify how we are communicating with contributors, and potential contributors.|
+|4. [Recognition of Good Work](./focus_areas/recognition/) | Identify how we recognize/reward good work in our community.|
+|5. [Leadership](./focus_areas/leadership/) | Identify how healthy our community leadership is.|
+|6. [Governance](./focus_areas/governance/) | Identify how diverse and inclusive our governance is.|
+|7. [Project Places](./focus_areas/project_and_community/) | Identify how diverse and inclusive our project places, where community engagement occurs, are.|
 
 Each area lists a collection of relevant questions. If you are interested in answering a question for your community, go to the associated resource page where we collect strategies for answering the question.
 

--- a/focus_areas/README.md
+++ b/focus_areas/README.md
@@ -10,6 +10,6 @@ We are compiling [dimensions of diversity and inclusion](./di_metrics.md) that c
 |4. [Recognition of Good Work](./focus_areas/recognition/) | Identify how we recognize/reward good work in our community.|
 |5. [Leadership](./focus_areas/leadership/) | Identify how healthy our community leadership is.|
 |6. [Governance](./focus_areas/governance/) | Identify how diverse and inclusive our governance is.|
-|7. [Project Places](./focus_areas/project_and_community/) | Identify how diverse and inclusive our project places, where community engagement occurs, are.|
+|7. [Project and Community](./focus_areas/project_and_community/) | Identify how diverse and inclusive our project places, where community engagement occurs, are.|
 
 Each area lists a collection of relevant questions. If you are interested in answering a question for your community, go to the associated resource page where we collect strategies for answering the question.

--- a/focus_areas/README.md
+++ b/focus_areas/README.md
@@ -1,0 +1,15 @@
+# Metrics Focus Areas
+
+We are compiling [dimensions of diversity and inclusion](./di_metrics.md) that can be used in the following areas of analysis:
+
+Focus Area | Goal 
+ --- | --- 
+1. [Event Diversity](./focus_areas/events/) | Identify the diversity and inclusion at events. 
+2. [Contributor Community Diversity](./focus_areas/contribution/) | Identify the diversity of the contributions within a community, and howe those different contributions are valued.
+3. [Communication Inclusivity](./focus_areas/communication/) | Identify how we are communicating with contributors, and potential contributors.
+4. [Recognition of Good Work](./focus_areas/recognition/) | Identify how we recognize/reward good work in our community.
+5. [Leadership](./focus_areas/leadership/) | Identify how healthy our community leadership is.
+6. [Governance](./focus_areas/governance/) | Identify how diverse and inclusive our governance is.
+7. [Project Places](./focus_areas/project_and_community/) | Identify how diverse and inclusive our project places, where community engagement occurs, are.
+
+Each area lists a collection of relevant questions. If you are interested in answering a question for your community, go to the associated resource page where we collect strategies for answering the question.

--- a/focus_areas/README.md
+++ b/focus_areas/README.md
@@ -2,14 +2,14 @@
 
 We are compiling [dimensions of diversity and inclusion](./di_metrics.md) that can be used in the following areas of analysis:
 
-Focus Area | Goal 
- --- | --- 
-1. [Event Diversity](./focus_areas/events/) | Identify the diversity and inclusion at events. 
-2. [Contributor Community Diversity](./focus_areas/contribution/) | Identify the diversity of the contributions within a community, and howe those different contributions are valued.
-3. [Communication Inclusivity](./focus_areas/communication/) | Identify how we are communicating with contributors, and potential contributors.
-4. [Recognition of Good Work](./focus_areas/recognition/) | Identify how we recognize/reward good work in our community.
-5. [Leadership](./focus_areas/leadership/) | Identify how healthy our community leadership is.
-6. [Governance](./focus_areas/governance/) | Identify how diverse and inclusive our governance is.
-7. [Project Places](./focus_areas/project_and_community/) | Identify how diverse and inclusive our project places, where community engagement occurs, are.
+| Focus Area | Goal |
+| --- | --- |
+|1. [Event Diversity](./focus_areas/events/) | Identify the diversity and inclusion at events. |
+|2. [Contributor Community Diversity](./focus_areas/contribution/) | Identify the diversity of the contributions within a community, and howe those different contributions are valued.|
+|3. [Communication Inclusivity](./focus_areas/communication/) | Identify how we are communicating with contributors, and potential contributors.|
+|4. [Recognition of Good Work](./focus_areas/recognition/) | Identify how we recognize/reward good work in our community.|
+|5. [Leadership](./focus_areas/leadership/) | Identify how healthy our community leadership is.|
+|6. [Governance](./focus_areas/governance/) | Identify how diverse and inclusive our governance is.|
+|7. [Project Places](./focus_areas/project_and_community/) | Identify how diverse and inclusive our project places, where community engagement occurs, are.|
 
 Each area lists a collection of relevant questions. If you are interested in answering a question for your community, go to the associated resource page where we collect strategies for answering the question.


### PR DESCRIPTION
- rename the "structure of repository" to "Metrics Focus Areas" in readme
- display focus areas as a table and show the goal in the right column
- create a new README in the focus_areas folder with the same table.