### PR TITLE
Add demographic dimenison: paid/unpaid

### DIFF
--- a/demographic-data/README.md
+++ b/demographic-data/README.md
@@ -33,6 +33,7 @@ NOTE: that the legal, privacy and ethical issues related to asking for, storing 
 11. Dis/Ability
 12. Caregiver (child or eldercare)
 13. Identifies as underrepresented (which can include components of above, or be separate)
+14. Paid contributor vs. unpaid volunteer contributor
 
 
 ## Metrics Focus Areas

--- a/demographic-data/README.md
+++ b/demographic-data/README.md
@@ -34,6 +34,7 @@ NOTE: that the legal, privacy and ethical issues related to asking for, storing 
 12. Caregiver (child or eldercare)
 13. Identifies as underrepresented (which can include components of above, or be separate)
 14. Paid contributor vs. unpaid volunteer contributor
+15. Organizational affiliation
 
 
 ## Metrics Focus Areas

--- a/demographic-data/README.md
+++ b/demographic-data/README.md
@@ -34,7 +34,6 @@ NOTE: that the legal, privacy and ethical issues related to asking for, storing 
 12. Caregiver (child or eldercare)
 13. Identifies as underrepresented (which can include components of above, or be separate)
 14. Paid contributor vs. unpaid volunteer contributor
-15. Organizational affiliation
 
 
 ## Metrics Focus Areas


### PR DESCRIPTION
This pull request adds `paid contributor vs. unpaid volunteer contributor` to Dimensions of Demographics

## Why?
[Luis Villa](https://github.com/tieguy) in an interview with me said the following: 

> You may have this cover under other kinds of other metrics, but one way of slicing contribution type is contribution motivation or support. So is this contribution being done by somebody who's being paid to work on open source full-time? Or is this contribution done by somebody who's being paid to work on open source part time? Or is this contribution being done purely as a volunteer?

I don't think that this is a separate metric but fits with our `Dimensions of Demographics`.