### PR TITLE
add demographic 'organizational affiliation'

### DIFF
--- a/demographic-data/README.md
+++ b/demographic-data/README.md
@@ -33,6 +33,7 @@ NOTE: that the legal, privacy and ethical issues related to asking for, storing 
 11. Dis/Ability
 12. Caregiver (child or eldercare)
 13. Identifies as underrepresented (which can include components of above, or be separate)
+14. Organizational affiliation
 
 
 ## Metrics Focus Areas


### PR DESCRIPTION
This pull request adds a demographics dimension `Organizational Affiliation`. 

A concern is whether organizational diversity is the kind of diversity and inclusion that the D&I Workgroup is working on.

By tracking this dimension of demographics, we enable people to run analyses on 'organizational diversity'. This is a much requested feature.

**During the WG call on Dec 10, we discussed:**
- Should organizational diversity be part of the D&I working group? Georg had as an answer from his set of surveys that this specific point was important for D&I.
- This specific point was initially not part of the D&I as people tend to gamify this, but is it important this information? Is more healthy an OSS project lead by a company or by several companies?
- This is related to the discussion about paid and unpaid developers in a community. (#140)
- Having different companies and different commercial view points helps in the health of the community.
- We may need a strong rationale for this discussion as having diversity of organizations may be seen as a discussion not related to D&I
- This discussion may be left for the general CHAOSS meetings.

**Current Proposal:** Discuss this at the CHAOSS hangout on December 11 with the larger CHAOSS community.