### PR TITLE
removed mailing archive mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Created a Pull Request. Gave feedback on our work. The team will try to update t
 but please open an issue or post on the mailing list if we've missed anyone.
 
 
-If you find yourself missing, please create a pull request or reach out to a maintainer. We started to maintain this list after starting the workgroup and are likely missing some of you, also because we lost our email archive. If you find yourself listed here and want to be removed, please create a pull request or ask a maintainer.
+If you find yourself missing, please create a pull request or reach out to a maintainer. We started to maintain this list after starting the workgroup and are likely missing some of you. If you find yourself listed here and want to be removed, please create a pull request or ask a maintainer.
 
 ## Related Works
 


### PR DESCRIPTION
We are in the process of restoring our mailing list archive. This pull requests removes an inaccurate qualifying sentence.