### PR TITLE
Adding Contribution-Type metric

### DIFF
--- a/focus_areas/contribution/contribution_type.md
+++ b/focus_areas/contribution/contribution_type.md
@@ -1,4 +1,4 @@
-# Contributions: Contribution-Type
+# Focus Area: Contributor Community Diversity
 
 ## Disclaimer / Caveats
 
@@ -8,38 +8,116 @@ Please feel free to [contribute](https://github.com/chaoss/wg-diversity-inclusio
 
 ## Question
 
-**Question:** Coding, Quality Assurance/Testing, Localization/L10N, Diversity & Inclusion, Event Organization, Documenting, Community Building/Management, Teaching, Trouble-shooting/Support, Creative/Design, Social Media, Writing Articles, Bug Triaging, UI/UX, Security/Campaign Advocacy
+**Question:** Do we recognize all contribution types in equal proportions?
 
 
 ## 1. Description
 
-_This section provides a rationale for why this question is important to diversity and inclusion._
-_Example for how to use this template: [Documentation](./resources/project_places-documentation.md)_
+Traditionally, open source projects have focused on code contributions as the primary currency for recognition and merit. This code-centric focus produces readily available metrics about code contributions because they are logged in a source code repository, however other, non-code contributions aren’t typically captured and shared.This overlooks the importance and necessity of multiple, varied contributions that make an open source project healthy, inclusive, and welcoming. Many projects have community members who do not write code but contribute in equally valuable ways by managing the community, triaging bugs, advertising the project, supporting users, or helping in other ways. A healthy community needs these different types of contributions and consequently, a project needs to recognize the people contributing. Once a project recognizes different contribution types, it becomes more welcoming to people who bring unique skills.
+
+How contributions are defined, quantified, tracked and made public is an unsolved question. The answer may be unique to each project. As a general guideline, it is difficult to compare different contribution types with each other and they might better be recognized independently.
+
+A project that lacks diverse contributions often suffers from negative outcomes, including poor documentation, poor CLA, unanswered legal questions, poor brand awareness, low community engagement, and few new contributors.
+
 
 ## 2. Sample Objectives
 
-- _This section provides a list of reasons a community wants to assess this question_
--
+- Acknowledge that many contribution types are required to advance an open source project.
+- Thank, reward, and recognize a variety of people with their skills and contributions.
+- Attract new people with different skills that are needed by project.
+- Avoid developer burnout by sharing tasks across contributors.
+- Demonstrate that project is mature and well-rounded with sufficient activity to support all related aspects.
+- Identify which tasks in a project require more attention.
+- Enable paths to leadership that are supportive of a variety of contribution types and people with varying expertise beyond coding.
 
 
 ## 3. Sample Strategies
 
-- _This section provides a list of methods available for answering the question._
--
+- Identify types of contributions a community makes to advance its project.
+- Ask community members to recognize someone for their contribution.
+- On the project website, list the leads of different parts of the project.
+- Track contributions through a dedicated system, e.g. issue tracker.
+- Measure contributions through collaboration tool log data.
+- Proxy contribution types through communication channel activity.
+- Train an artificial intelligence (AI) bot to detect and classify contributions.
 
 
 ## 4. Sample Success Metrics
+
+- Identify types of contributions a community makes to advance a project. The following list can help with brainstorming possible contribution types:
+  * Coding (can be separated further, e.g. front-end vs. backend)
+  * Bug Triaging
+  * Quality Assurance (QA) and Testing
+  * Security
+  * Localization/L10N and Translation
+  * Diversity & Inclusion
+  * Event Organization
+  * Documentation and Wiki
+  * Community Building and Management
+  * Teaching and Tutorial building
+  * Troubleshooting and Support
+  * Creative work and Design
+  * User Interface (UI) and User Experience (UX) and Accessibility
+  * Social Media
+  * User support and answering questions
+  * Writing Articles
+  * Public Relations - interviews with technical press
+  * Speaking at Events
+  * Marketing and Campaign Advocacy
+  * Website
+  * Legal
+  * Financial
+
+
 _Qualitative_
 
-- _This section provides detailed instructions for how to execute above listed qualitative methods and evaluate the results_
--
+- Ask community members to recognize someone for their contribution.
+  * Community members may notice that someone is making noteworthy contributions. Asking members to name the person and contribution can help identify who deserves recognition.
+  * This method recognizes contribution types that have previously not been considered.
+  * This method requires perceptive community members.
+  * This method sets a tone for the community, once the recognition is made public, for example via email or blog post, and people will follow similar behavior..
+- On the project website, list the leads of different parts of the project.
+  * Naturally, different parts of a project require different types of contribution. Recognizing the people managing the different project parts publicly on the website is a signal that contributions in these areas are valued. For example, documentation lead, quality assurance lead, security lead, translation lead, engineering lead, marketing lead, events lead, or the like.
+
 
 _Quantitative_
 
-- _This section provides detailed instructions for how to execute above listed quantitative methods and evaluate the results_
--
+- Track contributions through a dedicated system, e.g. issue tracker.
+  * Provide a way for community members to log their contributions. An issue can be opened for any type of contribution.
+  * The logging can include time spent on a contribution in an attempt to quantify contributions.
+- Measure contributions through collaboration tool log data.
+  * Code contributions can be counted from a source code repository. Wiki contributions can be counted from a wiki edit history. Email messages can be counted from an email archive. … See below for a list of sample data sources.
+  * Note: Account for activity from bots.
+- Proxy contribution types through communication channel activity.
+  * Explained by example: If quality assurance (QA) as its own mailing list, then activity around QA contributions can measured by proxy from mailing list activity. Similarly, conference organization may be coordinated through a Slack channel and activity there is a proxy for work done to organize a conference.
+  * Note: Account for activity from bots.
+- Train an artificial intelligence (AI) bot to detect and classify contributions.
+  * An AI can assist in categorizing contributions, for example, help requests vs. support provided, or feature request vs. bug reporting.
+
+_Sample data sources:_
+
+- Source code repository commit log
+- Wiki edit history
+- Forum history
+- Mailing list archives
+- Social media posts
+- Blog archive
+- Event talks
+- Meetup.com
+- Issue Tracker history
+
+_Other considerations:_
+
+- Especially with automated reports, allow community members to opt-out and not appear on the report.
+- Acknowledge imperfect capture of contribution types and be explicit about what types of contributions are - included.
+- As a project evolves, methods for collecting contribution type metrics will need to adapt. For example, when an internationalization library is exchanged, project activity around localization conceivably produces different metrics before and after the change.
+
 
 
 ## 5. Resources
 
-- _This section provides a list of resources and references_
+- https://medium.com/@sunnydeveloper/revisiting-the-word-recognition-in-foss-and-the-dream-of-open-credentials-d15385d49447
+- https://medium.com/@sunnydeveloper/technical-volunteer-needed-help-me-find-inclusivity-bugs-b13644bf583a
+- https://medium.com/@sunnydeveloper/squash-inclusion-bugs-982a3e5ee29d
+- https://24pullrequests.com/contributing
+- 14 Ways to contribute to open source without being a programmer: https://smartbear.com/blog/test-and-monitor/14-ways-to-contribute-to-open-source-without-being/

--- a/focus_areas/recognition/contribution_type.md
+++ b/focus_areas/recognition/contribution_type.md
@@ -1,4 +1,4 @@
-# Focus Area: Contribution Type
+# Focus Area: Recognition of Good Work
 
 ## Disclaimer / Caveats
 
@@ -8,45 +8,116 @@ Please feel free to [contribute](https://github.com/chaoss/wg-diversity-inclusio
 
 ## Question
 
-**Question:**   Does recognition skew to a particular kind of contribution? How are we missing altogether (see Contribution for a list of types identified to track)? 
+**Question:** Do we recognize all contribution types in equal proportions?
 
 
 ## 1. Description
 
-_This section provides a rationale for why this question is important to diversity and inclusion._
+Traditionally, open source projects have focused on code contributions as the primary currency for recognition and merit. This code-centric focus produces readily available metrics about code contributions because they are logged in a source code repository, however other, non-code contributions aren’t typically captured and shared.This overlooks the importance and necessity of multiple, varied contributions that make an open source project healthy, inclusive, and welcoming. Many projects have community members who do not write code but contribute in equally valuable ways by managing the community, triaging bugs, advertising the project, supporting users, or helping in other ways. A healthy community needs these different types of contributions and consequently, a project needs to recognize the people contributing. Once a project recognizes different contribution types, it becomes more welcoming to people who bring unique skills.
+
+How contributions are defined, quantified, tracked and made public is an unsolved question. The answer may be unique to each project. As a general guideline, it is difficult to compare different contribution types with each other and they might better be recognized independently.
+
+A project that lacks diverse contributions often suffers from negative outcomes, including poor documentation, poor CLA, unanswered legal questions, poor brand awareness, low community engagement, and few new contributors.
 
 
 ## 2. Sample Objectives
 
-- _This section provides a list of reasons a community wants to assess this question._
--
--
+- Acknowledge that many contribution types are required to advance an open source project.
+- Thank, reward, and recognize a variety of people with their skills and contributions.
+- Attract new people with different skills that are needed by project.
+- Avoid developer burnout by sharing tasks across contributors.
+- Demonstrate that project is mature and well-rounded with sufficient activity to support all related aspects.
+- Identify which tasks in a project require more attention.
+- Enable paths to leadership that are supportive of a variety of contribution types and people with varying expertise beyond coding.
 
 
 ## 3. Sample Strategies
 
-- _This section provides a list of methods available for answering the question._
--
--
+- Identify types of contributions a community makes to advance its project.
+- Ask community members to recognize someone for their contribution.
+- On the project website, list the leads of different parts of the project.
+- Track contributions through a dedicated system, e.g. issue tracker.
+- Measure contributions through collaboration tool log data.
+- Proxy contribution types through communication channel activity.
+- Train an artificial intelligence (AI) bot to detect and classify contributions.
 
 
 ## 4. Sample Success Metrics
+
+- Identify types of contributions a community makes to advance a project. The following list can help with brainstorming possible contribution types:
+  * Coding (can be separated further, e.g. front-end vs. backend)
+  * Bug Triaging
+  * Quality Assurance (QA) and Testing
+  * Security
+  * Localization/L10N and Translation
+  * Diversity & Inclusion
+  * Event Organization
+  * Documentation and Wiki
+  * Community Building and Management
+  * Teaching and Tutorial building
+  * Troubleshooting and Support
+  * Creative work and Design
+  * User Interface (UI) and User Experience (UX) and Accessibility
+  * Social Media
+  * User support and answering questions
+  * Writing Articles
+  * Public Relations - interviews with technical press
+  * Speaking at Events
+  * Marketing and Campaign Advocacy
+  * Website
+  * Legal
+  * Financial
+
+
 _Qualitative_
 
-- _This section provides detailed instructions for how to execute above listed qualitative methods and evaluate the results._
--
--
+- Ask community members to recognize someone for their contribution.
+  * Community members may notice that someone is making noteworthy contributions. Asking members to name the person and contribution can help identify who deserves recognition.
+  * This method recognizes contribution types that have previously not been considered.
+  * This method requires perceptive community members.
+  * This method sets a tone for the community, once the recognition is made public, for example via email or blog post, and people will follow similar behavior..
+- On the project website, list the leads of different parts of the project.
+  * Naturally, different parts of a project require different types of contribution. Recognizing the people managing the different project parts publicly on the website is a signal that contributions in these areas are valued. For example, documentation lead, quality assurance lead, security lead, translation lead, engineering lead, marketing lead, events lead, or the like.
 
 
 _Quantitative_
 
-- _This section provides detailed instructions for how to execute above listed quantitative methods and evaluate the results._
--
--
+- Track contributions through a dedicated system, e.g. issue tracker.
+  * Provide a way for community members to log their contributions. An issue can be opened for any type of contribution.
+  * The logging can include time spent on a contribution in an attempt to quantify contributions.
+- Measure contributions through collaboration tool log data.
+  * Code contributions can be counted from a source code repository. Wiki contributions can be counted from a wiki edit history. Email messages can be counted from an email archive. … See below for a list of sample data sources.
+  * Note: Account for activity from bots.
+- Proxy contribution types through communication channel activity.
+  * Explained by example: If quality assurance (QA) as its own mailing list, then activity around QA contributions can measured by proxy from mailing list activity. Similarly, conference organization may be coordinated through a Slack channel and activity there is a proxy for work done to organize a conference.
+  * Note: Account for activity from bots.
+- Train an artificial intelligence (AI) bot to detect and classify contributions.
+  * An AI can assist in categorizing contributions, for example, help requests vs. support provided, or feature request vs. bug reporting.
+
+_Sample data sources:_
+
+- Source code repository commit log
+- Wiki edit history
+- Forum history
+- Mailing list archives
+- Social media posts
+- Blog archive
+- Event talks
+- Meetup.com
+- Issue Tracker history
+
+_Other considerations:_
+
+- Especially with automated reports, allow community members to opt-out and not appear on the report.
+- Acknowledge imperfect capture of contribution types and be explicit about what types of contributions are - included.
+- As a project evolves, methods for collecting contribution type metrics will need to adapt. For example, when an internationalization library is exchanged, project activity around localization conceivably produces different metrics before and after the change.
+
 
 
 ## 5. Resources
 
-- _This section provides a list of resources and references that provide background information or support statements on this page._
--
--
+- https://medium.com/@sunnydeveloper/revisiting-the-word-recognition-in-foss-and-the-dream-of-open-credentials-d15385d49447
+- https://medium.com/@sunnydeveloper/technical-volunteer-needed-help-me-find-inclusivity-bugs-b13644bf583a
+- https://medium.com/@sunnydeveloper/squash-inclusion-bugs-982a3e5ee29d
+- https://24pullrequests.com/contributing
+- 14 Ways to contribute to open source without being a programmer: https://smartbear.com/blog/test-and-monitor/14-ways-to-contribute-to-open-source-without-being/


### PR DESCRIPTION
This pull request adds details to the metric Contribution-Type (fixes #116 ).

An initial version was created by Georg based on interviews.
Nicole, Sarah, and Daniel reviewed this metric during the weekly D&I meeting on 2019-01-14.

We still need to resolve the question of #122 What focus area should "Contribution Type" be in? Currently it lives in two but maintaining it will be difficult if we have duplication: 
- Contributor Community Diversity
- Recognition of Good Work

Lazy consensus: Unless objections are raised by January 28, we will merge this. Until then, all edits, comments, and feedback are welcome.