### PR TITLE
Update Mentorship metric page for the release cycle

### DIFF
--- a/focus-areas/leadership/mentorship.md
+++ b/focus-areas/leadership/mentorship.md
@@ -10,7 +10,7 @@
 Mentorship programs are a vital component in growing and sustaining a community by inviting newcomers to join a community and helping existing members grow within a community, thereby ensuring the health of the overall community. Through mentorship programs, we can invite diverse contributors and create inclusive environments for contributors to grow and ideally give back to the community.
 
 
-## 2. Sample Objectives
+## 2. Objectives
 
 - Increase the number and diversity of new contributors
 - Increase the level of contributions from each contributor, from a quantitative or qualitative perspective
@@ -20,7 +20,7 @@ Mentorship programs are a vital component in growing and sustaining a community 
 - Cultivate a culture of inclusivity through identifying and supporting mentors and mentees
 
 
-## 3. Sample Strategies
+## 3. Strategies
 
 - Ask Foundation members about existing formal or informal mentorship programs
 - Look for people informally mentoring new contributors (e.g., those reviewing newcomers in the code review process)
@@ -31,7 +31,7 @@ Mentorship programs are a vital component in growing and sustaining a community 
 - Collect demographic information from mentors and mentees
 
 
-## 4. Sample Success Metrics
+## 4. Success Metrics
 
 _Qualitative_
 

--- a/focus-areas/leadership/mentorship.md
+++ b/focus-areas/leadership/mentorship.md
@@ -1,16 +1,8 @@
 # Leadership - Mentorship
 
-
-## Disclaimer / Caveats
-
-**This is a work in process document being used to gather feedback and may not yet represent the views of the CHAOSS project.**
-
-Please feel free to [contribute](https://github.com/chaoss/wg-diversity-inclusion/blob/master/CONTRIBUTING.md) and improve this document.
-
-
 ## Question
 
-**Question:** How effective are our mentorship programs at increasing diversity and inclusion in our project?
+**Question:** How effective are our mentorship programs at supporting diversity and inclusion in our project?
 
 
 ## 1. Description
@@ -49,9 +41,9 @@ _Qualitative_
 - Mentee grew their professional network
 - Mentee has taken on responsibilities within community
 - Mentee contributes to community after end of mentorship project
-- Survey Likert item (1-5): I have found the mentoring experience personally rewarding.
-- Survey Likert item (1-5): I would recommend mentoring for this community.
-- Survey Likert item (1-5): I would recommend mentoring for this community.
+- Survey Likert item (1-4): I have found the mentoring experience personally rewarding.
+- Survey Likert item (1-4): I would recommend mentoring for this community.
+- Survey Likert item (1-4): I would recommend mentoring for this community.
 - Mentor survey feedback:
     * What training did you receive that helped your mentoring activity?
     * What community support was helpful for your mentoring activity?
@@ -68,7 +60,8 @@ _Quantitative_
 - Mentors experience (rounds or years mentored)
 - Geographic distribution of mentees
 - Retention rate of mentees vs the usual retention rate in the community
-- Variety of projects participating in the mentorship program (e.g., in the OpenStack Gender Report a few of them were participating)
+- Variety of projects participating in a mentorship program (e.g., in the OpenStack Gender Report a few of them were participating)
+- Variety of mentorship programs across a project ecosystem targeting different contribution levels (e.g., contribution ladder, onion layers)
 - Number of official mentors in the mentorship programs
     * How many mentors repeat the position in the following years
 


### PR DESCRIPTION
This has followed the Releasing guidelines at https://github.com/chaoss/metrics/blob/master/RELEASING.md.
These changes are intended to drive certain discussion. This is an agreement about the attendees
on the 3rd of June 2019.