### PR TITLE
update list of core contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ The collaboration guide is still in progress, but we’ve provided a few steps a
 
 - [Matt Germonprez](https://github.com/germonprez)
 - [Nicole Huesman](https://github.com/uoduckswtd1)
-- [Sarah Conway](https://github.com/SarahKConway)
+- [Matt Snell](https://github.com/Nebrethar)
+- [Kevin Lumbard](https://github.com/klumb)
+
 
 The criteria for becoming a core contributor is to participate at least once per month over a period of 3 months.
 Participation could include providing feedback in the weekly D&I meetings, providing feedback on docs, or


### PR DESCRIPTION
We have a rule for who should be listed as core contributors.
This PR is simply updating the README with the current core contributors.