### PR TITLE
Quick fix for Leader Types in Inclusive Leadership

### DIFF
--- a/focus-areas/leadership/inclusive-leadership.md
+++ b/focus-areas/leadership/inclusive-leadership.md
@@ -22,7 +22,7 @@ Signal to newcomers that everyone is welcome and everyone can be successful. Ens
 * Contributors with repository merge access
 * Contributors who are organization members for the repository
 * OS Program Board Members
-* Official Program Roles (Mozilla Reps, Mozilla Tech Speakers)
+* Official Program Roles (Program Representatives, Tech Speakers)
 * Those listed in project documents as contacts for issues with builds, documentation, etc.
 * Those with more than 5 pull requests to a project
 


### PR DESCRIPTION
The Types of Leadership section only specified Mozilla Representatives and Tech Speakers. I opened it up to include all program reps and tech speakers.

Signed-off-by: Matt Snell <msnell@unomaha.edu>