### PR TITLE
Standardize focus area READMEs

### DIFF
--- a/focus-areas/README.md
+++ b/focus-areas/README.md
@@ -1,15 +1,15 @@
-# Metrics Focus Areas
+# Focus Areas
 
 We are compiling [dimensions of diversity and inclusion](/demographic-data) that can be used in the following areas of analysis:
 
 | Focus Area | Goal |
 | --- | --- |
-|[Communication Inclusivity](./communication-inclusivity/) | Identify how we are communicating with contributors and potential contributors.|
-|[Contributor Community Diversity](./contributor-community-diversity/) | Identify the diversity of the contributions within a community, and how those different contributions are valued.|
-|[Event Diversity](./event-diversity/) | Identify the diversity and inclusion at events. |
-|[Governance](./governance/) | Identify how diverse and inclusive our governance is.|
-|[Leadership](./leadership/) | Identify how healthy our community leadership is.|
-|[Project and Community](./project-and-community/) | Identify how diverse and inclusive our project places, where community engagement occurs, are.|
-|[Recognition of Good Work](./recognition-of-good-work/) | Identify how we recognize / reward good work in our community.|
+|[Communication Inclusivity](communication-inclusivity) | Identify how we are communicating with contributors and potential contributors.|
+|[Contributor Community Diversity](contributor-community-diversity) | Identify the diversity of the contributions within a community, and how those different contributions are valued.|
+|[Event Diversity](event-diversity) | Identify the diversity and inclusion at events. |
+|[Governance](governance) | Identify how diverse and inclusive our governance is.|
+|[Leadership](leadership) | Identify how healthy our community leadership is.|
+|[Project and Community](project-and-community) | Identify how diverse and inclusive our project places, where community engagement occurs, are.|
+|[Recognition of Good Work](recognition-of-good-work) | Identify how we recognize / reward good work in our community.|
 
 Each area lists a collection of relevant questions. If you are interested in answering a question for your community, go to the associated resource page where we collect strategies for answering the question.

--- a/focus-areas/communication-inclusivity/README.md
+++ b/focus-areas/communication-inclusivity/README.md
@@ -1,4 +1,4 @@
-## Communication Inclusivity
+# Communication Inclusivity
 
 **Goal:** Identify how we are communicating with contributors, and potential contributors.
 

--- a/focus-areas/contributor-community-diversity/README.md
+++ b/focus-areas/contributor-community-diversity/README.md
@@ -1,4 +1,4 @@
-## Contributor Community Diversity
+# Contributor Community Diversity
 
 **Goal:** Identify the diversity of the contributions within a community, and howe those different contributions are valued.
 

--- a/focus-areas/event-diversity/README.md
+++ b/focus-areas/event-diversity/README.md
@@ -1,11 +1,11 @@
-## Event Diversity
+# Event Diversity
 
-Goal: Identify the diversity and inclusion at events.
+**Goal:** Identify the diversity and inclusion at events.
 
 Name | Question
 --- | ---
-[Speaker Demographics](./speaker-demographics.md) | How well does the speaker lineup for the event represent a diverse set of demographics?
-[Attendees Demographics](./attendee-demographics.md) | How diverse are the attendees?
+[Speaker Demographics](speaker-demographics.md) | How well does the speaker lineup for the event represent a diverse set of demographics?
+[Attendees Demographics](attendee-demographics.md) | How diverse are the attendees?
 [Diversity Access Tickets](diversity-access-tickets.md) | How are Diversity Access Tickets used to support diversity and inclusion for an event?
 [Code of Conduct at Event](event-code-of-conduct.md) | How does the Code of Conduct for events support diversity and inclusion?
 [Family Friendliness](family-friendly.md) | How does enabling families to attend together support diversity and inclusion of the event?

--- a/focus-areas/governance/README.md
+++ b/focus-areas/governance/README.md
@@ -1,6 +1,6 @@
-## Governance
+# Governance
 
-Goal: Identify how diverse and inclusive our governance is.
+**Goal:** Identify how diverse and inclusive our governance is.
 
 This one is a bit tricker, because governance varies by project.
 We might want to investigate or specifically call out governance model by [archetype](https://blog.mozilla.org/wp-content/uploads/2018/05/MZOTS_OS_Archetypes_report_ext_scr.pdf).

--- a/focus-areas/leadership/README.md
+++ b/focus-areas/leadership/README.md
@@ -1,13 +1,13 @@
-## Leadership
+# Leadership
 
-Goal: Identify how healthy our community leadership is.
+**Goal:** Identify how healthy our community leadership is.
 
 Name | Question
 --- | ---
 Leadership Diversity | Does the leadership team represent a diverse set of people?
-[Inclusive Leadership](./inclusive-leadership.md) |  How well is a project setup for diverse leadership?
-[Mentorship](./mentorship.md) | How effective are our mentorship programs at supporting diversity and inclusion in our project?
-[Sponsorship](./sponsorship.md) | How effective are long-time members who sponsor people in supporting diversity and inclusion in a community?
+[Inclusive Leadership](inclusive-leadership.md) |  How well is a project setup for diverse leadership?
+[Mentorship](mentorship.md) | How effective are our mentorship programs at supporting diversity and inclusion in our project?
+[Sponsorship](sponsorship.md) | How effective are long-time members who sponsor people in supporting diversity and inclusion in a community?
 Onboarding | Does the community have a structured or automated way to welcome new members and include them? (maybe move this into Governance? Have a new focus area for this?)
 
 

--- a/focus-areas/project-and-community/README.md
+++ b/focus-areas/project-and-community/README.md
@@ -1,4 +1,4 @@
-## Project & Communities
+# Project & Communities
 
 **Goal:** Identify how diverse and inclusive our project places, where community engagement occurs, are.
 

--- a/focus-areas/recognition-of-good-work/README.md
+++ b/focus-areas/recognition-of-good-work/README.md
@@ -1,6 +1,6 @@
-## Recognition of Good Work
+# Recognition of Good Work
 
-Goal: Identify how we recognize/reward good work in our community.
+**Goal:** Identify how we recognize/reward good work in our community.
 
 Name  |  Question
 --- | ---


### PR DESCRIPTION
The changes are from the recently added template for [focus-areas README](https://github.com/chaoss/governance/blob/master/templates/focus-areas.md)

Additionally, there is an additional subheading in READMEs -> `### Comments/Discussion`. This has been left unchanged.

Signed-off-by: Yash Prakash <yash2002109@gmail.com>